### PR TITLE
Fixed images tab not displaying properly

### DIFF
--- a/src/plugins/FavoriteMedia/index.js
+++ b/src/plugins/FavoriteMedia/index.js
@@ -1260,7 +1260,7 @@ module.exports = (Plugin, Library) => {
           index: heights.indexOf(Math.min(...heights))
         }
         const max = Math.max(...heights)
-        const itemHeight = Math.round(100 * itemWidth * medias[m].height / medias[m].width) / 100
+        const itemHeight = Math.round(100 * itemWidth * medias[m].height / itemWidth) / 100
         let placedIndex = placed.indexOf(false)
         if (placedIndex === -1) { placed.fill(false); placedIndex = 0 }
         if (this.props.type === 'audio') {


### PR DESCRIPTION
Fixes #183

Apparently Discord changed the way it renders the size of the image since now it displays them with a css `calc` function, this is only a temporary fix and probably isn't the best way to go about it.