### PR TITLE
fix: tenor images have new cdn link

### DIFF
--- a/src/plugins/FavoriteMedia/index.js
+++ b/src/plugins/FavoriteMedia/index.js
@@ -246,7 +246,7 @@ module.exports = (Plugin, Library) => {
     // tenor GIF case
     if (media.url.startsWith('https://tenor.com/view/')) {
       if (td.decode(mediaBuffer.slice(0, 15)) === '<!DOCTYPE html>') {
-        media.url = td.decode(mediaBuffer).match(/src="(https:\/\/media\.tenor\.com\/[^"]*)"/)?.[1]
+        media.url = td.decode(mediaBuffer).match(/src="(https:\/\/media\d\.tenor\.com\/[^"]*)"/)?.[1]
         media.name = media.url.match(/view\/(.*)-gif-/)?.[1]
         mediaBuffer = await BdApi.Net.fetch(media.url).then((r) => r.arrayBuffer())
       }


### PR DESCRIPTION
Downloads of tenor images have slightly broken. The images still download, however they are incorrect but not unrelated.

After visiting the site for the gif, the one that downloads instead is suggested to me on the right.

So I figured out that Tenor now uses `media1` as a subdomain and more than likely will have a `media2` or so, however I don't know how many. Though from what I can tell, [Certificate Search](https://crt.sh/?q=tenor.com) says there is only `media1`